### PR TITLE
SSL CA option

### DIFF
--- a/src/default-options.js
+++ b/src/default-options.js
@@ -25,6 +25,7 @@ exports.get = function() {
 		 */
 		sslKey: null,
 		sslCert: null,
+		sslCa: null,
 
 		/*
 		 * Data Manipulation

--- a/src/message/connection-endpoint.js
+++ b/src/message/connection-endpoint.js
@@ -32,10 +32,14 @@ var ConnectionEndpoint = function( options, readyCallback ) {
 	this._engineIoServerClosed = false;
 	this._server = null;
 	if( this._isHttpsServer() ) {
-		this._server = https.createServer({
+		var httpsOptions = {
 			key: this._options.sslKey,
 			cert: this._options.sslCert
-		});
+		};
+		if (this._options.sslCa) {
+			httpsOptions.ca = this._options.sslCa;
+		}
+		this._server = https.createServer(httpsOptions);
 	}
 	else {
 		this._server = http.createServer();

--- a/test/message/connection-endpointSpec.js
+++ b/test/message/connection-endpointSpec.js
@@ -55,6 +55,15 @@ describe( 'validates HTTPS server conditions', function() {
 		expect(httpsMock.createServer).toHaveBeenCalledWith( { "key": "sslPrivateKey", "cert": "sslCertificate"} );
 	});
 
+	it( 'creates a https connection when sslKey, sslCert and sslCa are provided', function(){
+		sslOptions.sslKey = 'sslPrivateKey';
+		sslOptions.sslCert = 'sslCertificate';
+		sslOptions.sslCa = 'sslCertificateAuthority';
+		connectionEndpointValidation = new ConnectionEndpoint( sslOptions );
+		expect(httpMock.createServer).not.toHaveBeenCalled();
+		expect(httpsMock.createServer).toHaveBeenCalledWith( { "key": "sslPrivateKey", "cert": "sslCertificate", "ca": "sslCertificateAuthority"} );
+	});
+
 	it( 'throws an exception when only sslCert is provided', function(){
 		try {
 			sslOptions.sslCert = 'sslCertificate';
@@ -74,6 +83,18 @@ describe( 'validates HTTPS server conditions', function() {
 			error = e;
 		} finally {
 			expect( error.message ).toBe( 'Must also include sslCert in order to use HTTPS' );
+		}
+	});
+
+	it( 'throws an exception when only sslCert and sslCa is provided', function(){
+		try {
+			sslOptions.sslCert = 'sslCertificate';
+			sslOptions.sslCa = 'sslCertificateAuthority';
+			connectionEndpointValidation = new ConnectionEndpoint( sslOptions );
+		} catch( e ) {
+			error = e;
+		} finally {
+			expect( error.message ).toBe( 'Must also include sslKey in order to use HTTPS' );
 		}
 	});
 });

--- a/test/message/connection-endpointSpec.js
+++ b/test/message/connection-endpointSpec.js
@@ -86,7 +86,7 @@ describe( 'validates HTTPS server conditions', function() {
 		}
 	});
 
-	it( 'throws an exception when only sslCert and sslCa is provided', function(){
+	it( 'throws an exception when sslCert and sslCa is provided', function(){
 		try {
 			sslOptions.sslCert = 'sslCertificate';
 			sslOptions.sslCa = 'sslCertificateAuthority';
@@ -95,6 +95,18 @@ describe( 'validates HTTPS server conditions', function() {
 			error = e;
 		} finally {
 			expect( error.message ).toBe( 'Must also include sslKey in order to use HTTPS' );
+		}
+	});
+
+	it( 'throws an exception when sslKey and sslCa is provided', function(){
+		try {
+			sslOptions.sslKey = "sslPrivateKey";
+			sslOptions.sslCa = 'sslCertificateAuthority';
+			connectionEndpointValidation = new ConnectionEndpoint( sslOptions );
+		} catch( e ) {
+			error = e;
+		} finally {
+			expect( error.message ).toBe( 'Must also include sslCert in order to use HTTPS' );
 		}
 	});
 });


### PR DESCRIPTION
We have an SSL certificate from GoDaddy where we need to provide an CA (Certificate authority) file. I tried to only add a key and certificate as sslKey and sslCert but this didn't work. With these patches added our SSL works fine. Don't know how to create any test(s) for this case, I'm afraid.